### PR TITLE
Allow library folders access for online test

### DIFF
--- a/webots.yml
+++ b/webots.yml
@@ -5,4 +5,4 @@ world:
   max-duration: 300
   metric: ranking
   higher-is-better: false
-dockerCompose: theia:webots-project/controllers/participant/
+dockerCompose: theia:webots-project/controllers/


### PR DESCRIPTION
This change allows users to have access to the motions and utils folder online. Thanks to the PR in [competition-record-action](https://github.com/cyberbotics/competition-record-action/pull/18) this shouldn't cause any other problems

Closes #15