### PR TITLE
Disable supervisor API for participants

### DIFF
--- a/worlds/wrestling.wbt
+++ b/worlds/wrestling.wbt
@@ -72,7 +72,6 @@ DEF WRESTLER_RED Nao {
   name "participant"
   controller "participant"
   window "competition_description"
-  supervisor TRUE
   synchronization FALSE
   selfCollision TRUE
 }


### PR DESCRIPTION
Hello,

In the current version, the robot of the participant is configured as a `supervisor`. This allows the submitted controllers to interact with the simulation, change the environment, and presumably also modify the state of the opponent's robot.

This PR disables the `supervisor` functionality for the participants to limit such "features" in the submitted controllers.


> Note: Only the red robot (participant) is currently configured as a `supervisor`. The blue robot (opponent) is unaffected.